### PR TITLE
Fixing bash 3 incompatibility with assoc. array

### DIFF
--- a/gh-repo-export
+++ b/gh-repo-export
@@ -139,7 +139,7 @@ else
 fi
 
 # Start migration of specified GitHub repositories
-declare -A MIGRATIONS
+declare -a MIGRATIONS
 
 start_migration() {
   local REPOSITORIES="$1"


### PR DESCRIPTION
Thanks to @joshjohanning for reporting and experimenting with a fix as this is more of a Bash 4+ solution.  Since the indices are integers, we don't technically need an associative array.